### PR TITLE
Added hosting of helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,4 +78,3 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create Release
 
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@v2.0.0
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -27,16 +27,6 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.4.0
-
-      - name: Package chart
-        run: |
-          helm package ./chart/hf-ec2-vmcontroller --app-version ${{ steps.get_version.outputs.version }} --version ${{ steps.get_version.outputs.version }}
-          ls -l *.tgz
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -56,7 +46,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: "gmehta3/hf-ec2-vmcontroller:${{ steps.get_version.outputs.version }}"
+          tags: ${{ github.repository }}:${{ steps.get_version.outputs.version }}
 
       - name: Create Release
         id: create_release
@@ -69,13 +59,23 @@ jobs:
           draft: true
           prerelease: false
 
-      - name: Upload Asset
-        id: helm-chart-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package and release chart
+        run: |
+          OWNER=${GITHUB_REPOSITORY%%/*}
+          REPO=${GITHUB_REPOSITORY#*/}
+
+          docker run -v $PWD:/app alpine/helm:3.0.0 package /app/chart/hf-shim-operator --app-version ${{ steps.get_version.outputs.version }} --version ${{ steps.get_version.outputs.version }} -d /app/dist
+          docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr upload --owner $OWNER --git-repo $REPO --package-path /app/dist --token ${{ secrets.GITHUB_TOKEN }}
+          docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr index  --owner $OWNER --git-repo $REPO --package-path /app/dist --charts-repo https://$OWNER.github.io/$REPO --index-path /app/docs/index.yaml
+
+      - name: commit updated index.yaml
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "update index.yaml" -a
+      
+      - name: push changes
+        uses: ad-m/github-push-action@master
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./hf-ec2-vmcontroller-${{ steps.get_version.outputs.version }}.tgz
-          asset_name: hf-ec2-vmcontroller-${{ steps.get_version.outputs.version }}.tgz
-          asset_content_type: application/zip
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    branches:
+    - master
+    paths:
+    - '**/Chart.yaml'
 
 name: Create Release
 
@@ -64,7 +66,7 @@ jobs:
           OWNER=${GITHUB_REPOSITORY%%/*}
           REPO=${GITHUB_REPOSITORY#*/}
 
-          docker run -v $PWD:/app alpine/helm:3.0.0 package /app/chart/hf-shim-operator --app-version ${{ steps.get_version.outputs.version }} --version ${{ steps.get_version.outputs.version }} -d /app/dist
+          docker run -v $PWD:/app alpine/helm:3.0.0 package /app/chart/hf-shim-operator -d /app/dist
           docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr upload --owner $OWNER --git-repo $REPO --package-path /app/dist --token ${{ secrets.GITHUB_TOKEN }}
           docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr index  --owner $OWNER --git-repo $REPO --package-path /app/dist --charts-repo https://$OWNER.github.io/$REPO --index-path /app/docs/index.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 on:
   push:
     # Sequence of patterns matched against refs/tags
-    branches:
-    - master
-    paths:
-    - '**/Chart.yaml'
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Create Release
 
@@ -66,7 +64,7 @@ jobs:
           OWNER=${GITHUB_REPOSITORY%%/*}
           REPO=${GITHUB_REPOSITORY#*/}
 
-          docker run -v $PWD:/app alpine/helm:3.0.0 package /app/chart/hf-shim-operator -d /app/dist
+          docker run -v $PWD:/app alpine/helm:3.0.0 package /app/chart/hf-shim-operator --app-version ${{ steps.get_version.outputs.version }} --version ${{ steps.get_version.outputs.version }} -d /app/dist
           docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr upload --owner $OWNER --git-repo $REPO --package-path /app/dist --token ${{ secrets.GITHUB_TOKEN }}
           docker run -v $PWD:/app quay.io/helmpack/chart-releaser:v0.2.3 cr index  --owner $OWNER --git-repo $REPO --package-path /app/dist --charts-repo https://$OWNER.github.io/$REPO --index-path /app/docs/index.yaml
 

--- a/chart/hf-shim-operator/Chart.yaml
+++ b/chart/hf-shim-operator/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.2.12
+appVersion: v0.1.1

--- a/chart/hf-shim-operator/Chart.yaml
+++ b/chart/hf-shim-operator/Chart.yaml
@@ -12,12 +12,10 @@ description: A Helm chart for Kubernetes
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+# This is set when the github action for releasing a version runs. See .github/workflows/release.yaml. 
+# The argument --version overrides this value.  
+version: 0.0.1
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.1.1
+# This is set when the github action for releasing a version runs. See .github/workflows/release.yaml. 
+# The argument --app-version overrides this value.  
+appVersion: v0.0.1

--- a/chart/hf-shim-operator/Chart.yaml
+++ b/chart/hf-shim-operator/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.1.1
+appVersion: v0.2.12

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# hf-shim-operator
+
+Interfaces with Hobbyfarm to provide creation of instances that match VirtualMachines. 
+
+Used with ec2-operator and droplet-operator to create EC2 and Droplet instances. 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,3 +1,13 @@
 apiVersion: v1
 entries:
-  hobbyfarm: []
+  hf-shim-operator:
+  - apiVersion: v2
+    appVersion: v0.2.11
+    created: "2021-05-06T21:43:13.23489306Z"
+    description: A Helm chart for Kubernetes
+    digest: 860536957454efaf3b95c3c6a6846b8219a08808317eaa4bb8b041bd3a938105
+    name: hf-shim-operator
+    urls:
+    - https://github.com/ebauman/hf-shim-operator/releases/download/hf-shim-operator-v0.2.11/hf-shim-operator-v0.2.11.tgz
+    version: v0.2.11
+generated: "2021-05-06T21:43:13.147056697Z"

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries:
+  hobbyfarm: []


### PR DESCRIPTION
This PR adds logic to automatically package and host helm charts when a new v.x.x. tag is applied. 
In addition to building and publishing the container image, this work will package and release a helm chart .tgz file.

There are also changes here (docs/) to host a github page so this repo can be referenced using `helm repo`