### PR TITLE
Added DeepCopy to hf shim update

### DIFF
--- a/pkg/controllers/virtualmachine_controller.go
+++ b/pkg/controllers/virtualmachine_controller.go
@@ -147,7 +147,7 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	// if ignoreVM is not true.. we need to requeue to make sure we check the
 	// ssh works
-	err = r.Status().Update(ctx, vm)
+	err = r.Status().Update(ctx, vm.DeepCopy())
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
When updating a VM, we were calling .Status().Update(ctx, vm), which overwrites the client-side resource with the server side resource after the update. This is not desirable here as we have both status AND annotations to update which cannot be done in a single call. The overwrite from server-side would blot out those annotations.

By passing the Status().Update() a DeepCopy'd object we don't overwrite the original and can use it later on L155 for the spec update. 